### PR TITLE
Added option for Gulp logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ gulp.task('watch', function () {
 });
 ```
 
-**bless(options)**. The (optional) `options` argument is passed on as is to [bless.js](https://github.com/paulyoung/bless.js).
+**bless(options)**. The (optional) `options` argument is passed on as is to [bless.js](https://github.com/paulyoung/bless.js). You can also include a `log` option to control whether Gulp should log output which defaults to `false` (this isn't passed to `bless.js`).
 
 Bless' options are listed here: [paulyoung/bless.js/blob/master/bin/blessc#L10](https://github.com/paulyoung/bless.js/blob/master/bin/blessc#L10).
 For example, if you wanted the first CSS chunk / "blessed" file to `@import` the others, then do this:
@@ -57,8 +57,6 @@ gulp.src('long.css')
         }))
         .pipe(gulp.dest('./'))
 ```
-
-You can also include a `log` property to control whether Gulp should log output.
 
 ##### A note about sourcemaps:
 If you're using a CSS pre-processor which creates inline sourcemaps [bless.js](https://github.com/paulyoung/bless.js) will take a very long time to run. It's recommended that you don't pass files containing inline sourcemaps to `gulp-bless`. If you do want to use sourcemaps then create them as a separate `.map` file.

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(options){
                     } else {
                         msg += 'not splitting.';
                     }
-                    if (options.log === true) {
+                    if (options.log) {
                         gutil.log(msg);
                     }
 


### PR DESCRIPTION
Typically Gulp plugins suppress the output of the native module and add an option to log the output. Basically:

``` js
.pipe(bless({
  log: true
}));
```

Gives the option of keeping the command line clean.
